### PR TITLE
feat: add spring integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     `maven-publish`
     id("org.jlleitschuh.gradle.ktlint") version "11.3.1"
     signing
+    id("org.springframework.boot") version "3.0.5" apply false
+    id("io.spring.dependency-management") version "1.1.0" apply false
 }
 
 group = "io.github.mscheong01"
@@ -33,14 +35,14 @@ subprojects {
     }
 
     tasks.withType<JavaCompile> {
-        sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-        targetCompatibility = JavaVersion.VERSION_1_8.toString()
+        sourceCompatibility = JavaVersion.VERSION_17.toString()
+        targetCompatibility = JavaVersion.VERSION_17.toString()
     }
 
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         kotlinOptions {
             freeCompilerArgs = listOf("-Xjsr305=strict")
-            jvmTarget = JavaVersion.VERSION_1_8.toString()
+            jvmTarget = JavaVersion.VERSION_17.toString()
         }
     }
 
@@ -110,6 +112,13 @@ subprojects {
         onlyIf {
             project.hasProperty("releaseVersion")
         }
+    }
+}
+
+project(":spring-boot-starter-interfAIce") {
+    apply {
+        plugin("org.springframework.boot")
+        plugin("io.spring.dependency-management")
     }
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,17 +1,15 @@
 
 dependencies {
-    // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-serialization-json
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
     // https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.15.1")
+    api("com.fasterxml.jackson.core:jackson-databind:2.15.1")
     // https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-kotlin
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.1")
+    api("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.1")
     // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${rootProject.ext["coroutinesVersion"]}")
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:${rootProject.ext["coroutinesVersion"]}")
     // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-reactor
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:${rootProject.ext["coroutinesVersion"]}}")
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:${rootProject.ext["coroutinesVersion"]}}")
     // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-reactive
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:${rootProject.ext["coroutinesVersion"]}")
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:${rootProject.ext["coroutinesVersion"]}")
     // https://mvnrepository.com/artifact/com.squareup.okhttp/okhttp
     implementation("com.squareup.okhttp:okhttp:2.7.5")
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.3")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,11 +7,11 @@ dependencies {
     // https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-kotlin
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.1")
     // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${rootProject.ext["coroutinesVersion"]}")
     // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-reactor
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.7.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:${rootProject.ext["coroutinesVersion"]}}")
     // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-reactive
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:1.7.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:${rootProject.ext["coroutinesVersion"]}")
     // https://mvnrepository.com/artifact/com.squareup.okhttp/okhttp
     implementation("com.squareup.okhttp:okhttp:2.7.5")
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.3")

--- a/core/src/main/kotlin/io/github/mscheong01/interfaice/MethodSpecification.kt
+++ b/core/src/main/kotlin/io/github/mscheong01/interfaice/MethodSpecification.kt
@@ -27,11 +27,14 @@ data class MethodSpecification(
     val returnType: KClass<out Any>
 ) {
     companion object {
-        fun from(method: Method, args: Array<out Any>): MethodSpecification {
+        fun from(method: Method, args: Array<out Any>?): MethodSpecification {
             val isSuspend = method.isSuspendingFunction()
             val parameters: List<ParameterSpecification>
             val returnType: KClass<out Any>
-            if (isSuspend) {
+            if (args == null) {
+                returnType = method.returnType.kotlin
+                parameters = listOf()
+            } else if (isSuspend) {
                 val continuation = method.genericParameterTypes.get(method.genericParameterTypes.size - 1)
                 returnType = ( // TODO: find alternative to this
                     (

--- a/core/src/main/kotlin/io/github/mscheong01/interfaice/openai/DefaultOkHttpOpenAiClient.kt
+++ b/core/src/main/kotlin/io/github/mscheong01/interfaice/openai/DefaultOkHttpOpenAiClient.kt
@@ -23,19 +23,19 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class DefaultOkHttpOpenAiClient : OpenAiApiAdapter {
-    private lateinit var apiKey: String
+    private lateinit var properties: OpenAiProperties
     private val client = OkHttpClient()
-    override fun setApiKey(apiKey: String) {
-        this.apiKey = apiKey
+    override fun setProperties(properties: OpenAiProperties) {
+        this.properties = properties
     }
 
     override suspend fun chat(request: ChatRequest): ChatResponse {
         val requestBody = mapper.writeValueAsString(request)
         println(requestBody)
         val httpRequest = Request.Builder()
-            .url("https://api.openai.com/v1/chat/completions")
+            .url("${properties.baseUrl}/v1/chat/completions")
             .post(RequestBody.create(MediaType.parse("application/json"), requestBody))
-            .header("Authorization", "Bearer $apiKey")
+            .header("Authorization", "Bearer ${properties.apiKey}")
             .build()
         return withContext(Dispatchers.IO) {
             with(client.newCall(httpRequest).execute()) {

--- a/core/src/main/kotlin/io/github/mscheong01/interfaice/openai/MockOpenAiApiAdapter.kt
+++ b/core/src/main/kotlin/io/github/mscheong01/interfaice/openai/MockOpenAiApiAdapter.kt
@@ -14,7 +14,7 @@
 package io.github.mscheong01.interfaice.openai
 
 class MockOpenAiApiAdapter : OpenAiApiAdapter {
-    override fun setApiKey(apiKey: String) {
+    override fun setProperties(properties: OpenAiProperties) {
         // do nothing
     }
 

--- a/core/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiChat.kt
+++ b/core/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiChat.kt
@@ -1,5 +1,6 @@
 package io.github.mscheong01.interfaice.openai
 
+@Target(AnnotationTarget.FUNCTION)
 annotation class OpenAiChat(
     val model: String = "gpt-3.5-turbo",
     val description: String = ""

--- a/core/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiInvocationHandler.kt
+++ b/core/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiInvocationHandler.kt
@@ -34,7 +34,7 @@ class OpenAiInvocationHandler(
 ) : InvocationHandler {
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    override fun invoke(proxy: Any, method: Method, args: Array<out Any>): Any? {
+    override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any? {
         val openAiChatAnnotation: OpenAiChat? = method.getAnnotation(OpenAiChat::class.java)
 
         if (openAiChatAnnotation != null) {
@@ -79,7 +79,7 @@ class OpenAiInvocationHandler(
             }
 
             // If it's a suspend function, use Kotlin coroutines to call the client in a non-blocking way
-            return if (method.isSuspendingFunction()) {
+            return if (args != null && args.isNotEmpty() && method.isSuspendingFunction()) {
                 val continuation = args.get(args.size - 1) as Continuation<Any>
                 val job = CoroutineScope(continuation.context).async {
                     responseMono.awaitSingle()

--- a/core/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiProperties.kt
+++ b/core/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiProperties.kt
@@ -13,7 +13,7 @@
 // limitations under the License.
 package io.github.mscheong01.interfaice.openai
 
-interface OpenAiApiAdapter {
-    fun setProperties(properties: OpenAiProperties)
-    suspend fun chat(request: ChatRequest): ChatResponse
-}
+data class OpenAiProperties(
+    val apiKey: String,
+    val baseUrl: String = "https://api.openai.com"
+)

--- a/core/src/test/kotlin/ProxyTest.kt
+++ b/core/src/test/kotlin/ProxyTest.kt
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test
 // See the License for the specific language governing permissions and
 // limitations under the License.
 class ProxyTest {
-    val proxy = OpenAiProxyFactory(System.getenv("OPENAI_API_KEY")).create(TestInterface::class.java)
+    val proxy = OpenAiProxyFactory.of(System.getenv("OPENAI_API_KEY")).create(TestInterface::class.java)
 
     @Test
     fun test() {

--- a/core/src/test/kotlin/io/github/mscheong01/interfaice/openai/DefaultOkHttpOpenAiClientTest.kt
+++ b/core/src/test/kotlin/io/github/mscheong01/interfaice/openai/DefaultOkHttpOpenAiClientTest.kt
@@ -8,7 +8,7 @@ internal class DefaultOkHttpOpenAiClientTest {
     @Test
     fun testChat(): Unit = runBlocking {
         val client = DefaultOkHttpOpenAiClient()
-        client.setApiKey(System.getenv("OPENAI_API_KEY"))
+        client.setProperties(OpenAiProperties(System.getenv("OPENAI_API_KEY")))
         val response = client.chat(
             ChatRequest(
                 model = "gpt-3.5-turbo",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 kotlin.code.style=official
-kotlin.code.style=official
+version=1.0.0-SNAPSHOT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,3 @@
 rootProject.name = "interfAIce"
 include("core")
+include("spring-boot-starter-interfAIce")

--- a/spring-boot-starter-interfAIce/build.gradle.kts
+++ b/spring-boot-starter-interfAIce/build.gradle.kts
@@ -3,12 +3,6 @@ dependencies {
     api(project(":core"))
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
-    // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${rootProject.ext["coroutinesVersion"]}")
-    // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-reactor
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:${rootProject.ext["coroutinesVersion"]}}")
-    // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-reactive
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:${rootProject.ext["coroutinesVersion"]}")
     annotationProcessor("org.springframework.boot:spring-boot-autoconfigure")
     annotationProcessor("org.springframework.boot:spring-boot-autoconfigure-processor")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/spring-boot-starter-interfAIce/build.gradle.kts
+++ b/spring-boot-starter-interfAIce/build.gradle.kts
@@ -1,0 +1,17 @@
+
+dependencies {
+    api(project(":core"))
+    implementation("org.springframework.boot:spring-boot-autoconfigure")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+    // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${rootProject.ext["coroutinesVersion"]}")
+    // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-reactor
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:${rootProject.ext["coroutinesVersion"]}}")
+    // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-reactive
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive:${rootProject.ext["coroutinesVersion"]}")
+    annotationProcessor("org.springframework.boot:spring-boot-autoconfigure")
+    annotationProcessor("org.springframework.boot:spring-boot-autoconfigure-processor")
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-webflux")
+}

--- a/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/InterfaiceAutoConfiguration.kt
+++ b/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/InterfaiceAutoConfiguration.kt
@@ -1,0 +1,45 @@
+// Copyright 2023 Minsoo Cheong
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package io.github.mscheong01.interfaice
+
+import io.github.mscheong01.interfaice.openai.OpenAiApiAdapter
+import io.github.mscheong01.interfaice.openai.OpenAiApiClient
+import io.github.mscheong01.interfaice.openai.OpenAiBeanFactoryPostProcessor
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+
+@EnableConfigurationProperties(InterfaiceConfigurationProperties::class)
+@AutoConfiguration
+open class InterfaiceAutoConfiguration {
+
+    @Bean
+    open fun openAiBeanFactoryPostProcessor(
+        openAiApiAdapter: OpenAiApiAdapter,
+    ): OpenAiBeanFactoryPostProcessor {
+        return OpenAiBeanFactoryPostProcessor(openAiApiAdapter)
+    }
+
+    @ConditionalOnMissingBean(OpenAiApiAdapter::class)
+    @Bean
+    open fun openAiApiClient(
+        properties: InterfaiceConfigurationProperties
+    ): OpenAiApiAdapter {
+        return OpenAiApiClient().apply {
+            setProperties(properties.openai)
+        }
+    }
+
+}

--- a/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/InterfaiceAutoConfiguration.kt
+++ b/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/InterfaiceAutoConfiguration.kt
@@ -27,7 +27,7 @@ open class InterfaiceAutoConfiguration {
 
     @Bean
     open fun openAiBeanFactoryPostProcessor(
-        openAiApiAdapter: OpenAiApiAdapter,
+        openAiApiAdapter: OpenAiApiAdapter
     ): OpenAiBeanFactoryPostProcessor {
         return OpenAiBeanFactoryPostProcessor(openAiApiAdapter)
     }
@@ -41,5 +41,4 @@ open class InterfaiceAutoConfiguration {
             setProperties(properties.openai)
         }
     }
-
 }

--- a/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/InterfaiceConfigurationProperties.kt
+++ b/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/InterfaiceConfigurationProperties.kt
@@ -11,9 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package io.github.mscheong01.interfaice.openai
+package io.github.mscheong01.interfaice
 
-interface OpenAiApiAdapter {
-    fun setProperties(properties: OpenAiProperties)
-    suspend fun chat(request: ChatRequest): ChatResponse
-}
+import io.github.mscheong01.interfaice.openai.OpenAiProperties
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "spring.interfaice")
+data class InterfaiceConfigurationProperties(
+    val openai: OpenAiProperties
+)

--- a/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiApiClient.kt
+++ b/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiApiClient.kt
@@ -21,13 +21,14 @@ import org.springframework.web.reactive.function.client.bodyToMono
 
 class OpenAiApiClient : OpenAiApiAdapter {
     private lateinit var properties: OpenAiProperties
-    val webClient = WebClient.builder()
-        .baseUrl(properties.baseUrl)
-        .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer ${properties.apiKey}")
-        .build()
+    private lateinit var webClient: WebClient
 
     override fun setProperties(properties: OpenAiProperties) {
         this.properties = properties
+        this.webClient = WebClient.builder()
+            .baseUrl(properties.baseUrl)
+            .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer ${properties.apiKey}")
+            .build()
     }
 
     override suspend fun chat(request: ChatRequest): ChatResponse {

--- a/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiApiClient.kt
+++ b/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiApiClient.kt
@@ -1,0 +1,41 @@
+// Copyright 2023 Minsoo Cheong
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package io.github.mscheong01.interfaice.openai
+
+import kotlinx.coroutines.reactive.awaitSingle
+import org.springframework.http.HttpHeaders
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
+
+class OpenAiApiClient : OpenAiApiAdapter {
+    private lateinit var properties: OpenAiProperties
+    val webClient = WebClient.builder()
+        .baseUrl(properties.baseUrl)
+        .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer ${properties.apiKey}")
+        .build()
+
+    override fun setProperties(properties: OpenAiProperties) {
+        this.properties = properties
+    }
+
+    override suspend fun chat(request: ChatRequest): ChatResponse {
+        return webClient.post()
+            .uri("/v1/chat/completions")
+            .body(BodyInserters.fromValue(request))
+            .retrieve()
+            .bodyToMono<ChatResponse>()
+            .awaitSingle()
+    }
+}

--- a/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiBeanFactoryPostProcessor.kt
+++ b/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiBeanFactoryPostProcessor.kt
@@ -22,7 +22,7 @@ import org.springframework.context.annotation.ClassPathScanningCandidateComponen
 import org.springframework.core.type.filter.AnnotationTypeFilter
 
 class OpenAiBeanFactoryPostProcessor(
-    openAiApiAdapter: OpenAiApiAdapter,
+    openAiApiAdapter: OpenAiApiAdapter
 ) : BeanFactoryPostProcessor {
 
     private val proxyFactory = OpenAiProxyFactory(openAiApiAdapter)
@@ -36,7 +36,7 @@ class OpenAiBeanFactoryPostProcessor(
                 return super.isCandidateComponent(beanDefinition) || beanDefinition.metadata.isAbstract
             }
         }.apply {
-            addIncludeFilter(AnnotationTypeFilter(OpenAiInterface::class.java, true, true));
+            addIncludeFilter(AnnotationTypeFilter(OpenAiInterface::class.java, true, true))
         }
 
         val candidates = provider.findCandidateComponents("io.github.mscheong01.interfaice") // TODO: Make this configurable

--- a/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiBeanFactoryPostProcessor.kt
+++ b/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiBeanFactoryPostProcessor.kt
@@ -1,0 +1,59 @@
+// Copyright 2023 Minsoo Cheong
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package io.github.mscheong01.interfaice.openai
+
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.beans.factory.support.AbstractBeanDefinition
+import org.springframework.beans.factory.support.BeanDefinitionRegistry
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.type.filter.AnnotationTypeFilter
+
+class OpenAiBeanFactoryPostProcessor(
+    openAiApiAdapter: OpenAiApiAdapter,
+) : BeanFactoryPostProcessor {
+
+    private val proxyFactory = OpenAiProxyFactory(openAiApiAdapter)
+
+    override fun postProcessBeanFactory(beanFactory: ConfigurableListableBeanFactory) {
+        if (beanFactory !is BeanDefinitionRegistry) {
+            return
+        }
+        val provider = object : ClassPathScanningCandidateComponentProvider(false) {
+            override fun isCandidateComponent(beanDefinition: AnnotatedBeanDefinition): Boolean {
+                return super.isCandidateComponent(beanDefinition) || beanDefinition.metadata.isAbstract
+            }
+        }.apply {
+            addIncludeFilter(AnnotationTypeFilter(OpenAiInterface::class.java, true, true));
+        }
+
+        val candidates = provider.findCandidateComponents("io.github.mscheong01.interfaice") // TODO: Make this configurable
+        for (candidate in candidates) {
+            try {
+                val beanClass = Class.forName(candidate.beanClassName)
+                beanFactory.registerBeanDefinition(
+                    beanClass.simpleName,
+                    candidate.apply {
+                        (this as AbstractBeanDefinition).setInstanceSupplier {
+                            proxyFactory.create(beanClass)
+                        }
+                    }
+                )
+            } catch (e: ClassNotFoundException) {
+                throw IllegalStateException("Unable to find class for bean: " + candidate.getBeanClassName())
+            }
+        }
+    }
+}

--- a/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiInterface.kt
+++ b/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiInterface.kt
@@ -1,0 +1,3 @@
+package io.github.mscheong01.interfaice.openai
+
+annotation class OpenAiInterface

--- a/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiInterface.kt
+++ b/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiInterface.kt
@@ -1,3 +1,13 @@
 package io.github.mscheong01.interfaice.openai
 
-annotation class OpenAiInterface
+import org.springframework.core.annotation.AliasFor
+import org.springframework.stereotype.Component
+
+@Target
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Component
+annotation class OpenAiInterface(
+    @get:AliasFor(annotation = Component::class)
+    val value: String = ""
+)

--- a/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiInterface.kt
+++ b/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/openai/OpenAiInterface.kt
@@ -3,7 +3,7 @@ package io.github.mscheong01.interfaice.openai
 import org.springframework.core.annotation.AliasFor
 import org.springframework.stereotype.Component
 
-@Target
+@Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
 @Component

--- a/spring-boot-starter-interfAIce/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-starter-interfAIce/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.github.mscheong01.interfaice.InterfaiceAutoConfiguration

--- a/spring-boot-starter-interfAIce/src/test/kotlin/io/github/mscheong01/interfaice/SpringIntegrationTest.kt
+++ b/spring-boot-starter-interfAIce/src/test/kotlin/io/github/mscheong01/interfaice/SpringIntegrationTest.kt
@@ -1,0 +1,39 @@
+// Copyright 2023 Minsoo Cheong
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package io.github.mscheong01.interfaice
+
+import io.github.mscheong01.interfaice.openai.OpenAiChat
+import io.github.mscheong01.interfaice.openai.OpenAiInterface
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@ActiveProfiles("test")
+@SpringBootTest
+class SpringIntegrationTest(
+    @Autowired val proxy: TestInterface
+) {
+    @OpenAiInterface
+    interface TestInterface {
+        @OpenAiChat
+        fun getGreetingMessage(): String
+    }
+
+    @Test
+    fun test() {
+        val result = proxy.getGreetingMessage()
+        println(result)
+    }
+}

--- a/spring-boot-starter-interfAIce/src/test/kotlin/io/github/mscheong01/interfaice/TestApplication.kt
+++ b/spring-boot-starter-interfAIce/src/test/kotlin/io/github/mscheong01/interfaice/TestApplication.kt
@@ -1,0 +1,24 @@
+// Copyright 2023 Minsoo Cheong
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package io.github.mscheong01.interfaice
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+open class TestApplication
+
+fun main(args: Array<String>) {
+    runApplication<TestApplication>(*args)
+}

--- a/spring-boot-starter-interfAIce/src/test/resources/application.yml
+++ b/spring-boot-starter-interfAIce/src/test/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  interfaice:
+    openai:
+      api-key: {OPENAI_API_KEY}
+  profiles:
+    active: test


### PR DESCRIPTION
add spring support.
Any interface annotated with `OpenAiInterface` will automatically have an OpenAi proxy bean registered.
Required configuration properties (api key, base url, etc) are injected via spring properties.
The api call will be done by `OpenAiApiClient`, which internally uses Spring Webclient and is configured as a singleton bean