### PR TITLE
[spring integration] feat: add EnableInterfaiceProxies annotation, make base packages configurable

### DIFF
--- a/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/EnableInterfaiceProxies.kt
+++ b/spring-boot-starter-interfAIce/src/main/kotlin/io/github/mscheong01/interfaice/EnableInterfaiceProxies.kt
@@ -1,0 +1,5 @@
+package io.github.mscheong01.interfaice
+
+annotation class EnableInterfaiceProxies(
+    val basePackages: Array<String> = []
+)

--- a/spring-boot-starter-interfAIce/src/test/kotlin/io/github/mscheong01/interfaice/TestApplication.kt
+++ b/spring-boot-starter-interfAIce/src/test/kotlin/io/github/mscheong01/interfaice/TestApplication.kt
@@ -16,6 +16,9 @@ package io.github.mscheong01.interfaice
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
+@EnableInterfaiceProxies(
+    basePackages = ["io.github.mscheong01.interfaice"]
+)
 @SpringBootApplication
 open class TestApplication
 


### PR DESCRIPTION
Make the base package value used for scanning interfaces configurable.
<img width="431" alt="image" src="https://github.com/mscheong01/interfAIce/assets/54794500/b8f08c1c-74f5-4630-a2ac-4e059c9d3c19">
