### PR TITLE
fix: add gradle Junit configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,6 +89,10 @@ subprojects {
                 }
             }
         }
+
+        tasks.withType<Test> {
+            useJUnitPlatform()
+        }
     }
 
     configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {


### PR DESCRIPTION
currently, junit tests are not running on `./gradlew test` because required configuration is missing